### PR TITLE
compare req.originalUrl rather than req.path 

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@
 
     return (req, res, next) => {
       if (io === null || io === undefined) {
-        
+
         io = require('socket.io')(req.socket.server);
 
         io.on('connection', (socket) => {
@@ -94,7 +94,9 @@
       }
 
       const startTime = process.hrtime();
-      if (req.path === config.path) {
+      const pathname = require('url').parse(req.originalUrl).pathname
+
+      if (pathname === config.path) {
         res.sendFile(path.join(__dirname + '/index.html'));
       } else {
         onHeaders(res, () => {


### PR DESCRIPTION
...to enable use in multi middleware authenticated routes with app.use([])

I was having trouble creating an authenticated route for the `/status` page using my existing middleware. The problem seemed to stem from the comparison of `req.path`, which when inside an array of middleware using a defined express route ended up being simply `/` inside the express-status-middleware module (thus the comparison looking for `/status` never matched). But if I compared `req.originalUrl` and used the `url` module to parse the pathname from *that* I could get the correct value when using this middleware process.

For example, instead of simply:

```
app.use(statusMonitor({
  path: '/status',
  socketPort: 41338,
  spans: []
}))
```

I want to specifically handle the `/status` path and apply some authentication/authorization middleware on top of it. Something like this:

```
app.use('/status', [
  requireToken,
  requireAdmin,
  statusMonitor({
    path: '/status',
    socketPort: 41338,
    spans: []
  })
])
```

By comparing `req.originalUrl` I can make this work, while not affecting the existing functionality ;)