### PR TITLE
unref interval

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,8 @@ const middlewareWrapper = (config) => {
       config.spans.forEach((span) => {
         span.os = [];
         span.responses = [];
-        setInterval(() => gatherOsMetrics(io, span), span.interval * 1000);
+        const interval = setInterval(() => gatherOsMetrics(io, span), span.interval * 1000);
+        interval.unref(); // don't keep node.js process up
       });
     }
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "express",
     "charts"
   ],
+  "engines" : {
+    "node" : ">=4"
+  },
   "author": "Rafal Wilinski <raf.wilinski@gmail.com> (http://rwilinski.me)",
   "contributors": [
     {


### PR DESCRIPTION
it is a good practice to unref the interval, if you don't want it to keep the node.js process running. This is not desirable in tests for example, as was pointed to me by @Pajk