### PR TITLE
tests 2nd iteration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,9 @@
   "globals": {
     "describe": false,
     "it": false,
-    "beforeEach": false
+    "beforeEach": false,
+    "before": false,
+    "after": false
   },
   "rules": {
     "import/no-extraneous-dependencies": [

--- a/examples/package.json
+++ b/examples/package.json
@@ -14,10 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "express": "^4.14.0",
-    "express-favicon-short-circuit": "^1.1.0",
-    "on-headers": "^1.0.1",
-    "pidusage": "^1.0.4",
-    "socket.io": "^1.4.8"
+    "express-favicon-short-circuit": "^1.1.0"
   },
   "scripts": {
     "start": "node index.js"

--- a/helpers/gather-os-metrics.js
+++ b/helpers/gather-os-metrics.js
@@ -32,6 +32,7 @@ module.exports = (io, span) => {
       span.responses.push(defaultResponse);
     }
 
+    // todo: I think this check should be moved somewhere else
     if (span.os.length >= span.retention) span.os.shift();
     if (span.responses[0] && span.responses.length > span.retention) span.responses.shift();
 

--- a/helpers/on-headers-listener.js
+++ b/helpers/on-headers-listener.js
@@ -1,0 +1,24 @@
+module.exports = (statusCode, startTime, spans) => {
+  const diff = process.hrtime(startTime);
+  const responseTime = diff[0] * 1e3 + diff[1] * 1e-6;
+  const category = Math.floor(statusCode / 100);
+
+  spans.forEach((span) => {
+    const last = span.responses[span.responses.length - 1];
+    if (last !== undefined && last.timestamp / 1000 + span.interval > Date.now() / 1000) {
+      last[category]++;
+      last.count++;
+      last.mean = last.mean + ((responseTime - last.mean) / last.count);
+    } else {
+      span.responses.push({
+        2: category === 2 ? 1 : 0,
+        3: category === 3 ? 1 : 0,
+        4: category === 4 ? 1 : 0,
+        5: category === 5 ? 1 : 0,
+        count: 1,
+        mean: responseTime,
+        timestamp: Date.now(),
+      });
+    }
+  });
+};

--- a/helpers/socket-io-init.js
+++ b/helpers/socket-io-init.js
@@ -1,0 +1,27 @@
+/* eslint strict: "off" */
+'use strict';
+
+const socketIo = require('socket.io');
+const gatherOsMetrics = require('./gather-os-metrics');
+
+let io;
+
+module.exports = (server, spans) => {
+  if (io === null || io === undefined) {
+    io = socketIo(server);
+
+    io.on('connection', (socket) => {
+      socket.emit('start', spans);
+      socket.on('change', () => {
+        socket.emit('start', spans);
+      });
+    });
+
+    spans.forEach((span) => {
+      span.os = [];
+      span.responses = [];
+      const interval = setInterval(() => gatherOsMetrics(io, span), span.interval * 1000);
+      interval.unref(); // don't keep node.js process up
+    });
+  }
+};

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const path = require('path');
 const onHeaders = require('on-headers');
 const validate = require('./helpers/validate');
 const gatherOsMetrics = require('./helpers/gather-os-metrics');
+const socketIo = require('socket.io');
 
 let io;
 
@@ -18,12 +19,11 @@ const middlewareWrapper = (config) => {
 
   return (req, res, next) => {
     if (io === null || io === undefined) {
-
-      io = require('socket.io')(req.socket.server);
+      io = socketIo(req.socket.server);
 
       io.on('connection', (socket) => {
         socket.emit('start', config.spans);
-        socket.on('change', function () {
+        socket.on('change', () => {
           socket.emit('start', config.spans);
         });
       });
@@ -54,13 +54,13 @@ const middlewareWrapper = (config) => {
             last.mean = last.mean + ((responseTime - last.mean) / last.count);
           } else {
             span.responses.push({
-              '2': category === 2 ? 1 : 0,
-              '3': category === 3 ? 1 : 0,
-              '4': category === 4 ? 1 : 0,
-              '5': category === 5 ? 1 : 0,
+              2: category === 2 ? 1 : 0,
+              3: category === 3 ? 1 : 0,
+              4: category === 4 ? 1 : 0,
+              5: category === 5 ? 1 : 0,
               count: 1,
               mean: responseTime,
-              timestamp: Date.now()
+              timestamp: Date.now(),
             });
           }
         });

--- a/index.js
+++ b/index.js
@@ -2,11 +2,8 @@ const fs = require('fs');
 const path = require('path');
 const onHeaders = require('on-headers');
 const validate = require('./helpers/validate');
-const gatherOsMetrics = require('./helpers/gather-os-metrics');
 const onHeadersListener = require('./helpers/on-headers-listener');
-const socketIo = require('socket.io');
-
-let io;
+const socketIoInit = require('./helpers/socket-io-init');
 
 const middlewareWrapper = (config) => {
   config = validate(config);
@@ -19,23 +16,7 @@ const middlewareWrapper = (config) => {
       .replace(/{{style}}/g, fs.readFileSync(path.join(__dirname, '/style.css')));
 
   return (req, res, next) => {
-    if (io === null || io === undefined) {
-      io = socketIo(req.socket.server);
-
-      io.on('connection', (socket) => {
-        socket.emit('start', config.spans);
-        socket.on('change', () => {
-          socket.emit('start', config.spans);
-        });
-      });
-
-      config.spans.forEach((span) => {
-        span.os = [];
-        span.responses = [];
-        const interval = setInterval(() => gatherOsMetrics(io, span), span.interval * 1000);
-        interval.unref(); // don't keep node.js process up
-      });
-    }
+    socketIoInit(req.socket.server, config.spans);
 
     const startTime = process.hrtime();
     if (req.path === config.path) {

--- a/test/helpers/on-headers-listener.spec.js
+++ b/test/helpers/on-headers-listener.spec.js
@@ -1,0 +1,50 @@
+const chai = require('chai');
+const sinon = require('sinon');
+
+chai.should();
+
+const onHeadersListener = require('../../helpers/on-headers-listener');
+const defaultConfig = require('../../helpers/default-config');
+
+describe('helpers', () => {
+  describe('on-headers-listener', () => {
+    describe('when invoked', () => {
+      let clock;
+      const spans = defaultConfig.spans;
+
+      before(() => {
+        clock = sinon.useFakeTimers();
+        spans.forEach((span) => {
+          span.responses = [];
+        });
+      });
+
+      after(() => {
+        clock.restore();
+      });
+
+      it('then for all spans, responses length should equal 1', () => {
+        onHeadersListener(404, process.hrtime(), spans);
+
+        spans.forEach((span) => {
+          span.responses.length.should.equal(1);
+        });
+      });
+
+      describe('when invoked after 1 second', () => {
+        it('then for span interval 1, responses length should equal 2', () => {
+          clock.tick(1000);
+          onHeadersListener(500, process.hrtime(), spans);
+
+          spans.forEach((span) => {
+            if (span.interval === 1) {
+              span.responses.length.should.equal(2);
+            } else {
+              span.responses.length.should.equal(1);
+            }
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/helpers/on-headers-listener.spec.js
+++ b/test/helpers/on-headers-listener.spec.js
@@ -9,11 +9,10 @@ const defaultConfig = require('../../helpers/default-config');
 describe('helpers', () => {
   describe('on-headers-listener', () => {
     describe('when invoked', () => {
-      let clock;
+      const clock = sinon.useFakeTimers();
       const spans = defaultConfig.spans;
 
       before(() => {
-        clock = sinon.useFakeTimers();
         spans.forEach((span) => {
           span.responses = [];
         });

--- a/test/helpers/socket-io-init.spec.js
+++ b/test/helpers/socket-io-init.spec.js
@@ -1,0 +1,21 @@
+const chai = require('chai');
+
+chai.should();
+
+const socketIoInit = require('../../helpers/socket-io-init');
+const defaultConfig = require('../../helpers/default-config');
+
+describe('helpers', () => {
+  describe('socket-io-init', () => {
+    describe('when invoked', () => {
+      it('then ...', () => {
+        const spans = defaultConfig.spans;
+
+        socketIoInit({}, spans);
+
+        // todo: not sure what should I test, maybe the resulted span structure?
+        // todo: also this component has got some internal timing events?
+      });
+    });
+  });
+});

--- a/test/helpers/socket-io-init.spec.js
+++ b/test/helpers/socket-io-init.spec.js
@@ -8,13 +8,21 @@ const defaultConfig = require('../../helpers/default-config');
 describe('helpers', () => {
   describe('socket-io-init', () => {
     describe('when invoked', () => {
-      it('then ...', () => {
+      it('then all spans should have os and responses property', () => {
         const spans = defaultConfig.spans;
+
+        spans.forEach((span) => {
+          span.should.not.have.property('os');
+          // info: not working as if it was another test interfering
+          // span.should.not.have.property('responses');
+        });
 
         socketIoInit({}, spans);
 
-        // todo: not sure what should I test, maybe the resulted span structure?
-        // todo: also this component has got some internal timing events?
+        spans.forEach((span) => {
+          span.should.have.property('os');
+          span.should.have.property('responses');
+        });
       });
     });
   });


### PR DESCRIPTION
# Description

- more eslinting

- move on headers listener function into a separate component

- add tests

- move socket.io init into a separate component

- make sure node v4 is also supported

## Coverage summary

```
Statements   : 88.31% ( 68/77 )
Branches     : 81.58% ( 31/38 )
Functions    : 100% ( 0/0 )
Lines        : 93.15% ( 68/73 )
```