### PR TITLE
Add new approach for authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ app.get('/status', ensureLoggedIn, require('express-status-monitor')())
 
 Credits to [@mattiaerre](https://github.com/mattiaerre)
 
+Example using [http-auth](https://www.npmjs.com/package/http-auth)
+```javascript
+const auth = require('http-auth');
+const basic = auth.basic({realm: 'Monitor Area'}, function(user, pass, callback) {
+  callback(user === 'username' && pass === 'password');
+});
+
+app.get('/status', auth.connect(basic), require('express-status-monitor')());
+```
+
 ## Tests and coverage
 
 In order to run test and coverage use the following npm commands:


### PR DESCRIPTION
I saw the last comments in some issues and PRs about the authentication and I looked that you decided to not implement the authentication in the module, leaving the user to choose/implement it.

The `README.md` describes an example using the [connect-ensure-login](https://www.npmjs.com/package/connect-ensure-login). This module requires a page to send the credentials in a kind of form, something like this. In my opinion, is a good suggestion when the user are using the `express` and have configured the views, static files .... But, for the cases that the framework are used just for an API? I think that, for this applications, the user wouldn't have any views configured.

Because of this, and I needed to implement for myself, an interesting approach to use as alternative of authentication is just using the [http-auth](https://www.npmjs.com/package/http-auth) with "Authentication Required" pop-up from browser.