### PR TITLE
middleware-wrapper: added a "pageRoute" property

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,17 @@ spans: [{
 
 ## Securing endpoint
 
+The HTML page handler is exposed as a `pageRoute` property on the main
+middleware function.  So the middleware is mounted to intercept all requests
+while the HTML page handler will be authenticated.
+
 Example using https://www.npmjs.com/package/connect-ensure-login
 ```javascript
 const ensureLoggedIn = require('connect-ensure-login').ensureLoggedIn()
 
-app.get('/status', ensureLoggedIn, require('express-status-monitor')())
+const statusMonitor = require('express-status-monitor')();
+app.use(statusMonitor);
+app.get('/status', ensureLoggedIn, statusMonitor.pageRoute)
 ```
 
 Credits to [@mattiaerre](https://github.com/mattiaerre)
@@ -73,7 +79,9 @@ const basic = auth.basic({realm: 'Monitor Area'}, function(user, pass, callback)
   callback(user === 'username' && pass === 'password');
 });
 
-app.get('/status', auth.connect(basic), require('express-status-monitor')());
+const statusMonitor = require('express-status-monitor')();
+app.use(statusMonitor);
+app.get('/status', auth.connect(basic), statusMonitor.pageRoute)
 ```
 
 ## Using module with socket.io in project

--- a/test/middleware-wrapper.spec.js
+++ b/test/middleware-wrapper.spec.js
@@ -34,6 +34,14 @@ describe('express-status-monitor', () => {
         middleware(req, res, next);
         sinon.assert.notCalled(res.send);
       });
+
+      describe('and used as separate middlware and page handler', () => {
+        it('exposes a page handler', () => {
+          middleware.pageRoute.should.be.an.instanceof(Function);
+          middleware.pageRoute(req, res, next);
+          sinon.assert.called(res.send);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
so HTML page request handler may be mounted independently of where status middleware is
inserted into the request chain.

Fixes #63