### PR TITLE
res.remove is invalid, replacing it with res.removeHeader

### DIFF
--- a/src/middleware-wrapper.js
+++ b/src/middleware-wrapper.js
@@ -25,7 +25,7 @@ const middlewareWrapper = config => {
 
     if (req.path === config.path) {
       if (config.iframe) {
-        res.remove(' X-Frame-Options');
+        res.removeHeader('X-Frame-Options');
       }
       res.send(renderedHtml);
     } else {


### PR DESCRIPTION
Fixing #74. Replacing res.remove with res.removeHeader to reset 'X-Frame-Options' Header.