### PR TITLE
Fixed runtime error for Node 6

### DIFF
--- a/src/middleware-wrapper.js
+++ b/src/middleware-wrapper.js
@@ -25,11 +25,11 @@ const middlewareWrapper = config => {
     .replace(/{{bodyClasses}}/g, bodyClasses)
     .replace(
       /{{script}}/g,
-      fs.readFileSync(path.join(__dirname, '/public/javascripts/app.js')),
+      fs.readFileSync(path.join(__dirname, '/public/javascripts/app.js'))
     )
     .replace(
       /{{style}}/g,
-      fs.readFileSync(path.join(__dirname, '/public/stylesheets/style.css')),
+      fs.readFileSync(path.join(__dirname, '/public/stylesheets/style.css'))
     );
 
   const middleware = (req, res, next) => {


### PR DESCRIPTION
When running the latest version of `express-status-monitor` under Node 6 we get the following error:
```
SyntaxError: Unexpected token )
    at createScript (vm.js:56:10)
    at Object.runInThisContext (vm.js:97:10)
    at Module._compile (module.js:542:28)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/hellofresh/src/checkout-fragment/0.33.0/node_modules/express-status-monitor/index.js:1:80)
/hellofresh/src/checkout-fragment/0.33.0/node_modules/express-status-monitor/src/middleware-wrapper.js:29
    )
```

You can reproduce this by going to https://npm.runkit.com/express-status-monitor and changing to Node 6.

The issue can be fixed by removing the unneeded comma under the `replace` API. 