### PR TITLE
Set ignoreStartsWith to /admin

### DIFF
--- a/src/helpers/default-config.js
+++ b/src/helpers/default-config.js
@@ -26,5 +26,5 @@ module.exports = {
     rps: true,
     statusCodes: true,
   },
-  ignoreStartsWith: '',
+  ignoreStartsWith: '/admin',
 };


### PR DESCRIPTION
Set ignoreStartsWith to /admin to align with README.  ignoreStartsWith set to empty string effectively ignored all routes.