### PR TITLE
Feature - Add custom socket path

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Default config:
 title: 'Express Status',  // Default title
 theme: 'default.css',     // Default styles
 path: '/status',
+socketPath: '/socket.io', // In case you use a custom path
 websocket: existingSocketIoInstance,
 spans: [{
   interval: 1,            // Every second

--- a/package.json
+++ b/package.json
@@ -44,6 +44,11 @@
       "name": "Jiri Spac",
       "email": "capajj@gmail.com",
       "url": "https://github.com/capaj/"
+    },
+    {
+      "name": "Max Findel",
+      "email": "max@terminal.co",
+      "url": "https://github.com/maxfindel/"
     }
   ],
   "repository": {

--- a/src/helpers/default-config.js
+++ b/src/helpers/default-config.js
@@ -2,6 +2,7 @@ module.exports = {
   title: 'Express Status',
   theme: 'default.css',
   path: '/status',
+  socketPath: '/socket.io',
   spans: [
     {
       interval: 1,

--- a/src/helpers/validate.js
+++ b/src/helpers/validate.js
@@ -18,6 +18,8 @@ module.exports = config => {
     typeof config.title === 'string' ? config.title : defaultConfig.title;
   config.path =
     typeof config.path === 'string' ? config.path : defaultConfig.path;
+  config.socketPath =
+    typeof config.socketPath === 'string' ? config.socketPath : defaultConfig.socketPath;
   config.spans =
     typeof config.spans === 'object' ? config.spans : defaultConfig.spans;
   config.port =

--- a/src/helpers/validate.js
+++ b/src/helpers/validate.js
@@ -16,6 +16,8 @@ module.exports = config => {
 
   config.title =
     typeof config.title === 'string' ? config.title : defaultConfig.title;
+  config.theme =
+    typeof config.theme === 'string' ? config.theme : defaultConfig.theme;
   config.path =
     typeof config.path === 'string' ? config.path : defaultConfig.path;
   config.socketPath =

--- a/src/middleware-wrapper.js
+++ b/src/middleware-wrapper.js
@@ -22,6 +22,7 @@ const middlewareWrapper = config => {
   const data = {
     title: validatedConfig.title,
     port: validatedConfig.port,
+    socketPath: validatedConfig.socketPath,
     bodyClasses: bodyClasses,
     script: fs.readFileSync(path.join(__dirname, '/public/javascripts/app.js')),
     style: fs.readFileSync(path.join(__dirname, '/public/stylesheets/', validatedConfig.theme))

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -90,6 +90,7 @@
 </div>
 <script>
   var port = '{{port}}';
+  var socketPath = '{{socketPath}}';
   {{{script}}}
 </script>
 </body>

--- a/src/public/javascripts/app.js
+++ b/src/public/javascripts/app.js
@@ -2,7 +2,7 @@
   eslint-disable no-plusplus, no-var, strict, vars-on-top, prefer-template,
   func-names, prefer-arrow-callback, no-loop-func
 */
-/* global Chart, location, document, port, parseInt, io */
+/* global Chart, location, document, port, socketPath, parseInt, io */
 
 'use strict';
 
@@ -13,7 +13,7 @@ Chart.defaults.global.elements.line.backgroundColor = 'rgba(0,0,0,0)';
 Chart.defaults.global.elements.line.borderColor = 'rgba(0,0,0,0.9)';
 Chart.defaults.global.elements.line.borderWidth = 2;
 
-var socket = io(location.protocol + '//' + location.hostname + ':' + (port || location.port));
+var socket = io(location.protocol + '//' + location.hostname + ':' + (port || location.port), { path: socketPath });
 var defaultSpan = 0;
 var spans = [];
 var statusCodesColors = ['#75D701', '#47b8e0', '#ffc952', '#E53A40'];


### PR DESCRIPTION
## Explanation
For environments where the express server is on a specific route and not on the root path, it is necessary to define a `path` configuration for sockets.io both in the server and the client. 
This PR adds the flexibility to override it.

## Changelog
- Added the field `socketPath` with default value in the config.
- Added default value for theme, in case on doesn't specify it on the config (it failed).