### PR TITLE
Use socketPath with init socket.io

### DIFF
--- a/src/helpers/socket-io-init.js
+++ b/src/helpers/socket-io-init.js
@@ -19,7 +19,7 @@ module.exports = (server, config) => {
     if (config.websocket !== null) {
       io = config.websocket;
     } else {
-      io = socketIo(server);
+      io = socketIo(server, { path: config.socketPath });
     }
 
     io.on('connection', socket => {


### PR DESCRIPTION
Took me a few hours to figure out why my custom socketPath didn't work, it turns out the socketPath was applied from the client but not from the server.

Sorry if the PR template is not correct or missing spec, please feel free to close this one if you think there is a better fix.

**Warning:** this may break other applications which already rely on the current (broken) behavior, only when `socketPath` is defined:

Old behavior:
- Use `/socketPath` at client side.
- Use `/` at server side.

New behavior:
- Use `/socketPath` at client side.
- Use `/socketPath` at server side.